### PR TITLE
custom local debugging config for image-based lambdas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,30 @@ init-db:
 
 image-local:
 	docker build -t case-scrape-local .
-	docker run -p 9000:8080 case-scrape-local:latest
+	docker run --env-file .env -p 9000:8080 case-scrape-local:latest 
 
-image-test-local:
-	curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{"case_number":"655783"}'
+image-local-debug:
+	echo "" >> requirements.txt && echo "debugpy" >> requirements.txt
+	docker build -t case-scrape-local .
+	sed -i '' '/debugpy/d' requirements.txt
+	docker run --env-file .env -p 9000:8080 -p 5890:5890 -e DEBUGPY=true case-scrape-local:latest 
+
+debug-event:
+	curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" --max-time 900 -d '{"case_number":"602708"}'
 
 update-ecr-image:
 	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 952753501735.dkr.ecr.us-east-1.amazonaws.com
 	docker build -t case-scrape .
 	docker tag case-scrape:latest 952753501735.dkr.ecr.us-east-1.amazonaws.com/case-scrape:latest
 	docker push 952753501735.dkr.ecr.us-east-1.amazonaws.com/case-scrape:latest
+
+clean:
+	docker stop case-scrape-local || true
+	docker rm case-scrape-local || true
+	docker rmi case-scrape-local:latest || true
 	
 update-lambda:
-	aws lambda update-function-code --function-name case-scrape --image-uri 952753501735.dkr.ecr.us-east-1.amazonaws.com/case-scrape:latest
+	aws lambda update-function-code --function-name criminal_case_scrape --image-uri 952753501735.dkr.ecr.us-east-1.amazonaws.com/case-scrape:latest
 
 pg-dump-from-aws:
 	pg_dump -Z 9 -v -h ${DATABASE_HOST} -U ${DATABASE_USER} -d ${DATABASE_NAME} | aws s3 cp --storage-class STANDARD --sse aws:kms - s3://my-bucket/dump.sql.gz

--- a/README.md
+++ b/README.md
@@ -128,4 +128,21 @@ for case in cases_to_scrape:
     time.sleep(random.randrange(15, 25))
 ```
 
+# To debug lambda locally
+
+1. Run Docker locally
+2. `make image-local-debug`
+3. `make debug-event`
+4. Drop breakpoints if you haven't
+5. In Run and Debug, click "Attach to Lambda Container" in Run and Debug
+6. If any container logs are open when the session times out, run `make clean` to remove unused resources
+
+### Why not use SAM to debug?
+
+Because SAM works better on zip-based lambdas, and this is an image-based lambda. For image-based lambdas, SAM is unable to reliably inject and use environment variables, and would still require manual insertion of `debugpy` and `wait_for_client()`. Check out the Makefile to understand the inner workings of debugging an image-based lambda.
+
+## Resources
+
+- https://medium.com/akava/deploying-containerized-aws-lambda-functions-with-terraform-7147b9815599
+
 (C) :fly:

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,6 +1,7 @@
 import random
 import re
 from datetime import datetime
+import os
 from typing import Tuple, Union, List
 
 import pandas as pd
@@ -24,20 +25,17 @@ from sqlalchemy.orm import Session
 from db import models
 
 
-### Functions for committing to database :)
-
-
 def check_tos(driver: WebDriver) -> webdriver.Chrome:
     # anticipates terms of service pop up
     driver.implicitly_wait(random.randrange(1, 5))
-    if "TOS" in driver.current_url:
-        try:
-            WebDriverWait(driver, 10).until(
-                EC.element_to_be_clickable((By.ID, "SheetContentPlaceHolder_btnYes"))
-            ).click()
-        except WebDriverException:
-            return driver
-        driver.implicitly_wait(3)
+    try:
+        WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable(
+                (By.ID, "SheetContentPlaceHolder_btnYes"))
+        ).click()
+    except WebDriverException:
+        return driver
+    driver.implicitly_wait(3)
     return driver
 
 
@@ -56,7 +54,8 @@ def search_case_number(driver: WebDriver, case_number: str) -> webdriver.Chrome:
 
     if len(driver.find_elements(By.ID, "SheetContentPlaceHolder_btnYes")) > 0:
         WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.ID, "SheetContentPlaceHolder_btnYes"))
+            EC.element_to_be_clickable(
+                (By.ID, "SheetContentPlaceHolder_btnYes"))
         ).click()
         WebDriverWait(driver, 10).until(
             EC.element_to_be_clickable(
@@ -112,7 +111,7 @@ def get_table(
         data_list = [d.text for d in data]
     table = {}
     for i, h in enumerate(headers):
-        table[h.text.upper().strip()] = data_list[i :: len(headers)]
+        table[h.text.upper().strip()] = data_list[i:: len(headers)]
     df = pd.DataFrame(table)
     df["CASE_NUMBER"] = case_number
     df.fillna("", inplace=True)
@@ -218,8 +217,9 @@ def fetch_case_summary_tables(engine, driver, case_number) -> Tuple[WebDriver, s
         header_xpath="//table[(@id = 'SheetContentPlaceHolder_caseCharges_gvCharges')]//th",
         data_xpath="//table[(@id = 'SheetContentPlaceHolder_caseCharges_gvCharges')]//td",
     )
-    charge_df.rename(columns={"type": "charge_type"}, inplace=True)
-    # delete all before adding them if they exist
+    charge_df.rename(columns={"type": "charge_type",
+                     "TYPE": "charge_type"}, inplace=True)
+    # delete all before adding them, if they exist
     with Session(engine) as db:
         if (
             len(
@@ -242,7 +242,8 @@ def fetch_case_summary_tables(engine, driver, case_number) -> Tuple[WebDriver, s
         header_xpath="//table[(@id = 'SheetContentPlaceHolder_caseBondInfo_gvBonds')]//th",
         data_xpath="//table[(@id = 'SheetContentPlaceHolder_caseBondInfo_gvBonds')]//td",
     )
-    bond_df.rename(columns={"type": "bond_type"}, inplace=True)
+    bond_df.rename(columns={"type": "bond_type",
+                   "TYPE": "bond_type"}, inplace=True)
     with Session(engine) as db:
         if (
             len(
@@ -338,7 +339,8 @@ def fetch_cost_info(
         data_xpath="//table[(@id = 'SheetContentPlaceHolder_caseCosts_gvCosts')]//td",
     )
     # remove "Total" row, as we can calculate this ourselves.
-    cost_table = cost_table[cost_table["ACCOUNT"].str.contains("TOTAL") == False]
+    cost_table = cost_table[cost_table["ACCOUNT"].str.contains(
+        "TOTAL") == False]
 
     with Session(engine) as db:
         if (
@@ -535,10 +537,16 @@ def update_case(engine, case_number, status):
         db.commit()
 
 
-### The lambda handler!!!
+# The lambda handler!!!
 
 
 def lambda_handler(event, context):
+
+    if os.getenv("DEBUGPY"):
+        import debugpy
+        debugpy.listen(("0.0.0.0", 5890))
+        debugpy.wait_for_client()
+
     case_no_str = event["case_number"]
     opts = Options()
     opts.binary_location = "/opt/chrome/chrome"
@@ -569,17 +577,21 @@ def lambda_handler(event, context):
             )
             data_elems[i].click()
             driver, case_number = fetch_case_summary(engine, driver)
-            driver, case_number = fetch_case_summary_tables(engine, driver, case_number)
-            driver, case_number = fetch_docket_info(engine, driver, case_number)
+            driver, case_number = fetch_case_summary_tables(
+                engine, driver, case_number)
+            driver, case_number = fetch_docket_info(
+                engine, driver, case_number)
             driver.back()
             driver = check_tos(driver)
             driver, case_number = fetch_cost_info(engine, driver, case_number)
             driver.back()
             driver = check_tos(driver)
-            driver, case_number = fetch_defendant_info(engine, driver, case_number)
+            driver, case_number = fetch_defendant_info(
+                engine, driver, case_number)
             driver.back()
             driver = check_tos(driver)
-            driver, case_number = fetch_attorney_info(engine, driver, case_number)
+            driver, case_number = fetch_attorney_info(
+                engine, driver, case_number)
             driver.back()
             driver = check_tos(driver)
             driver.back()
@@ -587,11 +599,15 @@ def lambda_handler(event, context):
     else:
         try:
             driver, case_number = fetch_case_summary(engine, driver)
-            driver, case_number = fetch_case_summary_tables(engine, driver, case_number)
-            driver, case_number = fetch_docket_info(engine, driver, case_number)
+            driver, case_number = fetch_case_summary_tables(
+                engine, driver, case_number)
+            driver, case_number = fetch_docket_info(
+                engine, driver, case_number)
             driver, case_number = fetch_cost_info(engine, driver, case_number)
-            driver, case_number = fetch_defendant_info(engine, driver, case_number)
-            driver, case_number = fetch_attorney_info(engine, driver, case_number)
+            driver, case_number = fetch_defendant_info(
+                engine, driver, case_number)
+            driver, case_number = fetch_attorney_info(
+                engine, driver, case_number)
             update_case(engine, case_no_str, "Data Obtained")
             driver.close()
             driver.quit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pandas==1.3.5
+pandas==2.0.3
+numpy==1.24.3
 SQLAlchemy==1.4.46
 selenium==4.4.2
 psycopg2-binary


### PR DESCRIPTION
Contrary to what the vibes may code, SAM is not the solution for image-based lambdas like cuya_courts.

### Why not use SAM to debug?

Because SAM works better on zip-based lambdas, and this is an image-based lambda. For image-based lambdas, SAM is unable to reliably inject and use environment variables, and would still require manual insertion of `debugpy` and `wait_for_client()`. Check out the Makefile to understand the inner workings of debugging an image-based lambda.
